### PR TITLE
Harden the login session flow

### DIFF
--- a/src/components/nav-header/c-cpns/header-info.vue
+++ b/src/components/nav-header/c-cpns/header-info.vue
@@ -44,15 +44,11 @@
 </template>
 
 <script setup lang="ts" name="header-info">
-import { useRouter } from 'vue-router'
-import { localCache } from '@/utils/cache'
+import useLoginStore from '@/store/login/login'
 
-const router = useRouter()
+const loginStore = useLoginStore()
 function handleExitClick() {
-  localCache.deleteCache('token')
-  localCache.deleteCache('userInfo')
-  localCache.deleteCache('userMenus')
-  router.push('/login')
+  loginStore.logoutAction()
 }
 </script>
 

--- a/src/hooks/usePermission.ts
+++ b/src/hooks/usePermission.ts
@@ -3,7 +3,6 @@ import useLoginStore from '@/store/login/login'
 function usePermission(pageName: string, handleName: string) {
   const queryPermission = `${pageName}:${handleName}`
   const permissions = useLoginStore().permissions
-  console.log(queryPermission, permissions)
   return !!permissions.find((item) => item.includes(queryPermission))
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,5 +16,3 @@ for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
 app.use(store)
 app.use(router)
 app.mount('#app')
-
-console.log('testtst')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 import { localCache } from '@/utils/cache'
+import type { IMenu } from '@/service/login/types'
 import { firstRoute, mapMenuToRoutes } from '@/utils/map-menu'
 import { createRouter, createWebHashHistory } from 'vue-router'
 
@@ -26,7 +27,7 @@ const router = createRouter({
   ]
 })
 
-export function addRoutesWithMenu(menus: any) {
+export function addRoutesWithMenu(menus: IMenu[]) {
   // 1.获取匹配到的所有的路由
   const routes = mapMenuToRoutes(menus)
 
@@ -37,7 +38,7 @@ export function addRoutesWithMenu(menus: any) {
 }
 
 router.beforeEach((to) => {
-  const token = localCache.getCache('token')
+  const token = localCache.getCache<string>('token')
   if (to.path.startsWith('/main') && !token) {
     return '/login'
   }

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,5 +1,7 @@
 import HYRequest from './request'
 import { BASE_URL1, TIME_OUT1 } from './config'
+import router from '@/router'
+import { clearAuthCache } from '@/utils/auth'
 import { localCache } from '@/utils/cache'
 
 const hyRequest = new HYRequest({
@@ -7,7 +9,7 @@ const hyRequest = new HYRequest({
   timeout: TIME_OUT1,
   interceptors: {
     requestInterceptor: (config) => {
-      const token = localCache.getCache('token')
+      const token = localCache.getCache<string>('token')
       if (token && config.headers) {
         config.headers.Authorization = `Bearer ${token}`
       }
@@ -20,6 +22,12 @@ const hyRequest = new HYRequest({
       return res
     },
     responseInterceptorCatch: (err) => {
+      if (err?.response?.status === 401) {
+        clearAuthCache()
+        if (router.currentRoute.value.path !== '/login') {
+          void router.push('/login')
+        }
+      }
       return Promise.reject(err)
     }
   }

--- a/src/service/login/login.ts
+++ b/src/service/login/login.ts
@@ -1,20 +1,21 @@
 import hyRequest from '..'
+import type { IAccountLoginParams, IApiResponse, ILoginData, IMenu, IUserInfo } from './types'
 
-export function accountLogin(account: any) {
-  return hyRequest.post({
+export function accountLogin(account: IAccountLoginParams) {
+  return hyRequest.post<IApiResponse<ILoginData>>({
     url: '/login',
     data: account
   })
 }
 
 export function getUserById(id: number) {
-  return hyRequest.get({
+  return hyRequest.get<IApiResponse<IUserInfo>>({
     url: '/users/' + id
   })
 }
 
 export function getRoleMenus(id: number) {
-  return hyRequest.get({
+  return hyRequest.get<IApiResponse<IMenu[]>>({
     url: `/role/${id}/menu`
   })
 }

--- a/src/service/login/types.ts
+++ b/src/service/login/types.ts
@@ -1,0 +1,55 @@
+export interface IApiResponse<T> {
+  code: number
+  data: T
+}
+
+export interface IAccountLoginParams {
+  name: string
+  password: string
+}
+
+export interface ILoginData {
+  id: number
+  name: string
+  token: string
+}
+
+export interface IRole {
+  id: number
+  name: string
+  intro: string
+  createAt: string
+  updateAt: string
+}
+
+export interface IDepartment {
+  id: number
+  name: string
+  parentId: number | null
+  createAt: string
+  updateAt: string
+  leader: string
+}
+
+export interface IUserInfo {
+  id: number
+  name: string
+  realname: string
+  cellphone: number
+  enable: number
+  createAt: string
+  updateAt: string
+  role: IRole
+  department: IDepartment | null
+}
+
+export interface IMenu {
+  id: number
+  name: string
+  type: number
+  url: string
+  icon: string
+  sort: number
+  permission?: string
+  children?: IMenu[]
+}

--- a/src/store/login/login.ts
+++ b/src/store/login/login.ts
@@ -1,5 +1,7 @@
 import router, { addRoutesWithMenu } from '@/router'
 import { accountLogin, getRoleMenus, getUserById } from '@/service/login/login'
+import type { IAccountLoginParams, IMenu, IUserInfo } from '@/service/login/types'
+import { clearAuthCache } from '@/utils/auth'
 import { localCache } from '@/utils/cache'
 import { mapMenuToPersssions } from '@/utils/map-menu'
 import { defineStore } from 'pinia'
@@ -7,20 +9,20 @@ import useMainStore from '../main/main'
 
 interface ILoginState {
   token: string
-  userInfo: any
-  userMenus: any[]
+  userInfo: IUserInfo | null
+  userMenus: IMenu[]
   permissions: string[]
 }
 
 const useLoginStore = defineStore('login', {
   state: (): ILoginState => ({
     token: '',
-    userInfo: {},
+    userInfo: null,
     userMenus: [],
     permissions: []
   }),
   actions: {
-    async accountLoginAction(account: any) {
+    async accountLoginAction(account: IAccountLoginParams) {
       // 1.获取登录信息
       const loginRes = await accountLogin(account)
       const { id, token } = loginRes.data
@@ -32,7 +34,7 @@ const useLoginStore = defineStore('login', {
       // 3.获取用户信息
       const userRes = await getUserById(id)
       this.userInfo = userRes.data
-      localCache.setCache('useInfo', this.userInfo)
+      localCache.setCache('userInfo', this.userInfo)
 
       // 4.根据role的id获取菜单
       const roleId = this.userInfo.role.id
@@ -57,16 +59,23 @@ const useLoginStore = defineStore('login', {
     },
 
     loadLocalDataAction() {
-      this.token = localCache.getCache('token')
-      this.userInfo = localCache.getCache('userInfo')
-      this.userMenus = localCache.getCache('userMenus')
-      this.permissions = localCache.getCache('permissions')
+      this.token = localCache.getCache<string>('token') ?? ''
+      this.userInfo = localCache.getCache<IUserInfo>('userInfo') ?? null
+      this.userMenus = localCache.getCache<IMenu[]>('userMenus') ?? []
+      this.permissions = localCache.getCache<string[]>('permissions') ?? []
 
-      if (this.token && this.userMenus) {
+      if (this.token && this.userMenus.length) {
         addRoutesWithMenu(this.userMenus) // 获取所有的数据
         const mainStore = useMainStore()
         mainStore.fetchEntireDataAction()
       }
+    },
+
+    logoutAction() {
+      this.$reset()
+      useMainStore().$reset()
+      clearAuthCache()
+      router.push('/login')
     }
   }
 })

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,9 @@
+import { localCache } from './cache'
+
+const authCacheKeys = ['token', 'userInfo', 'userMenus', 'permissions', 'password'] as const
+
+export function clearAuthCache() {
+  for (const key of authCacheKeys) {
+    localCache.deleteCache(key)
+  }
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -10,14 +10,19 @@ class HYCache {
     this.storage = type === CacheType.local ? localStorage : sessionStorage
   }
 
-  setCache(key: string, value: any) {
+  setCache<T>(key: string, value: T) {
     this.storage.setItem(key, JSON.stringify(value))
   }
 
-  getCache(key: string) {
+  getCache<T>(key: string): T | undefined {
     const value = this.storage.getItem(key)
-    if (value) {
-      return JSON.parse(value)
+    if (!value) return undefined
+
+    try {
+      return JSON.parse(value) as T
+    } catch {
+      this.deleteCache(key)
+      return undefined
     }
   }
 

--- a/src/views/login/c-cpns/login-panel.vue
+++ b/src/views/login/c-cpns/login-panel.vue
@@ -22,8 +22,8 @@
       </el-tab-pane>
     </el-tabs>
     <div class="control-account">
-      <el-checkbox v-model="isKeep" label="记住密码" />
-      <el-link type="primary">记住密码</el-link>
+      <el-checkbox v-model="isKeep" label="记住账号" />
+      <el-link type="primary">记住账号</el-link>
     </div>
     <el-button type="primary" class="login-btn" @click="loginAciton">立即登录</el-button>
   </div>
@@ -36,15 +36,19 @@ import PanelAccount from './panel-account.vue'
 import { localCache } from '@/utils/cache'
 
 const currentTab = ref('account')
-const isKeep = ref<boolean>(localCache.getCache('rem_pwd'))
+const isKeep = ref<boolean>(
+  localCache.getCache<boolean>('remember_account') ??
+    localCache.getCache<boolean>('rem_pwd') ??
+    false
+)
 watch(isKeep, (newValue) => {
-  localCache.setCache('rem_pwd', newValue)
+  localCache.setCache('remember_account', newValue)
+  localCache.deleteCache('rem_pwd')
 })
 
 const accountRef = ref<InstanceType<typeof PanelAccount>>()
 
 function loginAciton() {
-  console.log('立即登录')
   accountRef.value?.loginAction(isKeep.value)
 }
 </script>

--- a/src/views/login/c-cpns/panel-account.vue
+++ b/src/views/login/c-cpns/panel-account.vue
@@ -21,9 +21,13 @@ import { localCache } from '@/utils/cache'
 
 // 定义内部的数据
 const account = reactive({
-  name: localCache.getCache('name') ?? '',
-  password: localCache.getCache('password') ?? ''
+  name:
+    localCache.getCache<string>('rememberedAccount') ?? localCache.getCache<string>('name') ?? '',
+  password: ''
 })
+
+// Older versions stored the password in localStorage. Remove it when the login form loads.
+localCache.deleteCache('password')
 
 // 定义form的验证规则
 const accountRules: FormRules = {
@@ -42,20 +46,24 @@ const formRef = ref<FormInstance>()
 const loginStore = useLoginStore()
 function loginAction(isKeep: boolean) {
   // 是否通过了验证
-  formRef.value?.validate((isValid) => {
+  formRef.value?.validate(async (isValid) => {
     if (isValid) {
       const name = account.name
       const password = account.password
-      // 1.登录操作
-      loginStore.accountLoginAction({ name, password })
 
-      // 2.记住密码
+      // Remember the account name only. Passwords must not be persisted in localStorage.
       if (isKeep) {
-        localCache.setCache('name', name)
-        localCache.setCache('password', password)
-      } else {
+        localCache.setCache('rememberedAccount', name)
         localCache.deleteCache('name')
-        localCache.deleteCache('password')
+      } else {
+        localCache.deleteCache('rememberedAccount')
+        localCache.deleteCache('name')
+      }
+
+      try {
+        await loginStore.accountLoginAction({ name, password })
+      } catch {
+        ElMessage.error('登录失败，请检查账号或密码')
       }
     } else {
       ElMessage.warning({ message: '账号或者密码输入的规则错误~' })


### PR DESCRIPTION
## What changed

- Added TypeScript models for login, user, role, department, and menu responses.
- Fixed the persisted user info cache key and made cache parsing resilient to invalid JSON.
- Changed the login form to remember only the account name instead of storing passwords in localStorage.
- Added a shared logout flow that resets Pinia state and clears authentication data.
- Redirected expired sessions to the login page on HTTP 401 responses.
- Removed leftover login-related debug output.

## Validation

- `npm ci`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Verified login, authenticated user profile, and role menu requests against the new API.
- Verified the production preview login page and confirmed there are no browser console errors.
