### PR TITLE
Modernize the request layer

### DIFF
--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import HYRequest from './request'
 import { BASE_URL1, TIME_OUT1 } from './config'
 import router from '@/router'
@@ -22,7 +23,7 @@ const hyRequest = new HYRequest({
       return res
     },
     responseInterceptorCatch: (err) => {
-      if (err?.response?.status === 401) {
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
         clearAuthCache()
         if (router.currentRoute.value.path !== '/login') {
           void router.push('/login')

--- a/src/service/login/login.ts
+++ b/src/service/login/login.ts
@@ -1,5 +1,6 @@
 import hyRequest from '..'
-import type { IAccountLoginParams, IApiResponse, ILoginData, IMenu, IUserInfo } from './types'
+import type { IApiResponse } from '../types'
+import type { IAccountLoginParams, ILoginData, IMenu, IUserInfo } from './types'
 
 export function accountLogin(account: IAccountLoginParams) {
   return hyRequest.post<IApiResponse<ILoginData>>({

--- a/src/service/login/types.ts
+++ b/src/service/login/types.ts
@@ -1,7 +1,6 @@
-export interface IApiResponse<T> {
-  code: number
-  data: T
-}
+import type { IDepartment, IRole } from '../main/types'
+
+export type { IDepartment, IMenu, IRole } from '../main/types'
 
 export interface IAccountLoginParams {
   name: string
@@ -14,23 +13,6 @@ export interface ILoginData {
   token: string
 }
 
-export interface IRole {
-  id: number
-  name: string
-  intro: string
-  createAt: string
-  updateAt: string
-}
-
-export interface IDepartment {
-  id: number
-  name: string
-  parentId: number | null
-  createAt: string
-  updateAt: string
-  leader: string
-}
-
 export interface IUserInfo {
   id: number
   name: string
@@ -41,15 +23,4 @@ export interface IUserInfo {
   updateAt: string
   role: IRole
   department: IDepartment | null
-}
-
-export interface IMenu {
-  id: number
-  name: string
-  type: number
-  url: string
-  icon: string
-  sort: number
-  permission?: string
-  children?: IMenu[]
 }

--- a/src/service/main/system.ts
+++ b/src/service/main/system.ts
@@ -1,72 +1,74 @@
 import hyRequest from '..'
+import type { IApiResponse, IPaginatedData } from '../types'
+import type { IDepartment, IMenu, IPageQuery, IRole, IUser } from './types'
 
 /** 用户的网络请求 */
-export function getUserListData(queryInfo: any) {
-  return hyRequest.post({
+export function getUserListData(queryInfo: IPageQuery) {
+  return hyRequest.post<IApiResponse<IPaginatedData<IUser>>, IPageQuery>({
     url: '/users/list',
     data: queryInfo
   })
 }
 
-export function newUserData(userInfo: any) {
-  return hyRequest.post({
+export function newUserData(userInfo: Partial<IUser>) {
+  return hyRequest.post<IApiResponse<IUser>, Partial<IUser>>({
     url: '/users',
     data: userInfo
   })
 }
 
 export function deleteUserData(id: number) {
-  return hyRequest.delete({
+  return hyRequest.delete<IApiResponse<unknown>>({
     url: '/users/' + id
   })
 }
 
-export function editUserData(id: number, userInfo: any) {
-  return hyRequest.patch({
+export function editUserData(id: number, userInfo: Partial<IUser>) {
+  return hyRequest.patch<IApiResponse<IUser>, Partial<IUser>>({
     url: '/users/' + id,
     data: userInfo
   })
 }
 
 /** 获取页面的数据 */
-export function getPageListData(pageName: string, queryInfo: any) {
-  return hyRequest.post({
+export function getPageListData(pageName: string, queryInfo: IPageQuery) {
+  return hyRequest.post<IApiResponse<IPaginatedData<Record<string, unknown>>>, IPageQuery>({
     url: `/${pageName}/list`,
     data: queryInfo
   })
 }
 
 export function deletePageData(pageName: string, id: number) {
-  return hyRequest.delete({
+  return hyRequest.delete<IApiResponse<unknown>>({
     url: `/${pageName}/${id}`
   })
 }
 
-export function newPageData(pageName: string, dataInfo: any) {
-  return hyRequest.post({
+export function newPageData(pageName: string, dataInfo: Record<string, unknown>) {
+  return hyRequest.post<IApiResponse<Record<string, unknown>>, Record<string, unknown>>({
     url: `/${pageName}`,
     data: dataInfo
   })
 }
 
-export function editPageData(pageName: string, id: number, dataInfo: any) {
-  return hyRequest.patch({
+export function editPageData(pageName: string, id: number, dataInfo: Record<string, unknown>) {
+  return hyRequest.patch<IApiResponse<Record<string, unknown>>, Record<string, unknown>>({
     url: `/${pageName}/${id}`,
     data: dataInfo
   })
 }
 
 /** 获取部门的信息 */
-export function getDepartmentData(queryInfo: any) {
-  return hyRequest.post({
+export function getDepartmentData(queryInfo: IPageQuery) {
+  return hyRequest.post<IApiResponse<IPaginatedData<IDepartment>>, IPageQuery>({
     url: '/department/list',
     data: queryInfo
   })
 }
 
 /** 获取角色的信息 */
-export function getRoleData(queryInfo: any) {
-  return hyRequest.post({
+export function getRoleData(queryInfo: IPageQuery) {
+  return hyRequest.post<IApiResponse<IPaginatedData<IRole>>, IPageQuery>({
     url: '/role/list',
     data: queryInfo
   })
@@ -74,7 +76,7 @@ export function getRoleData(queryInfo: any) {
 
 /** 获取菜单的信息 */
 export function getMenuData() {
-  return hyRequest.post({
+  return hyRequest.post<IApiResponse<IPaginatedData<IMenu>>>({
     url: '/menu/list'
   })
 }

--- a/src/service/main/types.ts
+++ b/src/service/main/types.ts
@@ -1,0 +1,44 @@
+export interface IPageQuery {
+  offset: number
+  size: number
+}
+
+export interface IUser {
+  id: number
+  name: string
+  realname: string
+  cellphone: number
+  enable: number
+  departmentId: number
+  roleId: number
+  createAt: string
+  updateAt: string
+}
+
+export interface IDepartment {
+  id: number
+  name: string
+  parentId: number | null
+  createAt: string
+  updateAt: string
+  leader: string
+}
+
+export interface IRole {
+  id: number
+  name: string
+  intro: string
+  createAt: string
+  updateAt: string
+}
+
+export interface IMenu {
+  id: number
+  name: string
+  type: number
+  url: string
+  icon: string
+  sort: number
+  permission?: string
+  children?: IMenu[]
+}

--- a/src/service/request/index.ts
+++ b/src/service/request/index.ts
@@ -1,15 +1,15 @@
 import axios from 'axios'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 
-interface HYInstanceInterceptors<T = AxiosResponse> {
-  requestInterceptor?: (config: AxiosRequestConfig) => AxiosRequestConfig
-  requestInterceptorCatch?: (err: any) => any
+interface HYInstanceInterceptors<T = AxiosResponse, D = unknown> {
+  requestInterceptor?: (config: AxiosRequestConfig<D>) => AxiosRequestConfig<D>
+  requestInterceptorCatch?: (err: unknown) => unknown
   responseInterceptor?: (res: T) => T
-  responseInterceptorCatch?: (err: any) => any
+  responseInterceptorCatch?: (err: unknown) => unknown
 }
 
-interface HYRequestConfig<T = AxiosResponse> extends AxiosRequestConfig {
-  interceptors?: HYInstanceInterceptors<T>
+interface HYRequestConfig<T = AxiosResponse, D = unknown> extends AxiosRequestConfig<D> {
+  interceptors?: HYInstanceInterceptors<T, D>
 }
 
 class HYRequest {
@@ -48,43 +48,41 @@ class HYRequest {
     )
   }
 
-  request<T = any>(config: HYRequestConfig<T>) {
-    if (config.interceptors?.requestInterceptor) {
-      config = config.interceptors.requestInterceptor(config)
+  async request<T = unknown, D = unknown>(config: HYRequestConfig<T, D>): Promise<T> {
+    let requestConfig = config
+
+    if (requestConfig.interceptors?.requestInterceptor) {
+      requestConfig = requestConfig.interceptors.requestInterceptor(requestConfig)
     }
 
-    return new Promise<T>((resolve, reject) => {
-      this.instance
-        .request<any, T>(config)
-        .then((res) => {
-          if (config.interceptors?.responseInterceptor) {
-            res = config.interceptors.responseInterceptor(res)
-          }
-          resolve(res)
-        })
-        .catch((err: any) => {
-          if (config.interceptors?.responseInterceptorCatch) {
-            err = config.interceptors.responseInterceptorCatch(err)
-          }
-          reject(err)
-        })
-    })
+    try {
+      let response = (await this.instance.request<unknown, T, D>(requestConfig)) as T
+      if (requestConfig.interceptors?.responseInterceptor) {
+        response = requestConfig.interceptors.responseInterceptor(response)
+      }
+      return response
+    } catch (error: unknown) {
+      if (requestConfig.interceptors?.responseInterceptorCatch) {
+        throw await requestConfig.interceptors.responseInterceptorCatch(error)
+      }
+      throw error
+    }
   }
 
-  get<T = any>(config: HYRequestConfig<T>) {
-    return this.request<T>({ ...config, method: 'GET' })
+  get<T = unknown, D = unknown>(config: HYRequestConfig<T, D>) {
+    return this.request<T, D>({ ...config, method: 'GET' })
   }
 
-  post<T = any>(config: HYRequestConfig<T>) {
-    return this.request<T>({ ...config, method: 'POST' })
+  post<T = unknown, D = unknown>(config: HYRequestConfig<T, D>) {
+    return this.request<T, D>({ ...config, method: 'POST' })
   }
 
-  delete<T = any>(config: HYRequestConfig<T>) {
-    return this.request<T>({ ...config, method: 'DELETE' })
+  delete<T = unknown, D = unknown>(config: HYRequestConfig<T, D>) {
+    return this.request<T, D>({ ...config, method: 'DELETE' })
   }
 
-  patch<T = any>(config: HYRequestConfig<T>) {
-    return this.request<T>({ ...config, method: 'PATCH' })
+  patch<T = unknown, D = unknown>(config: HYRequestConfig<T, D>) {
+    return this.request<T, D>({ ...config, method: 'PATCH' })
   }
 }
 

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -1,0 +1,9 @@
+export interface IApiResponse<T> {
+  code: number
+  data: T
+}
+
+export interface IPaginatedData<T> {
+  list: T[]
+  totalCount: number
+}

--- a/src/store/main/main.ts
+++ b/src/store/main/main.ts
@@ -1,10 +1,11 @@
 import { getDepartmentData, getMenuData, getRoleData } from '@/service/main/system'
+import type { IDepartment, IMenu, IRole } from '@/service/main/types'
 import { defineStore } from 'pinia'
 
 interface IMainState {
-  entireDepartments: any[]
-  entireRoles: any[]
-  entireMenus: any[]
+  entireDepartments: IDepartment[]
+  entireRoles: IRole[]
+  entireMenus: IMenu[]
 }
 
 const useMainStore = defineStore('main', {

--- a/src/store/main/system/system.ts
+++ b/src/store/main/system/system.ts
@@ -8,6 +8,7 @@ import {
   newPageData,
   newUserData
 } from '@/service/main/system'
+import type { IPageQuery, IUser } from '@/service/main/types'
 import { defineStore } from 'pinia'
 import type { ISystemState } from './type'
 
@@ -19,14 +20,14 @@ const useSystemStore = defineStore('system', {
     pageTotalCount: 0
   }),
   actions: {
-    async getUserListDataAction(queryInfo: any) {
+    async getUserListDataAction(queryInfo: IPageQuery) {
       // 1.请求用户列表数据
       const userListResult = await getUserListData(queryInfo)
       const { list, totalCount } = userListResult.data
       this.usersList = list
       this.usersTotalCount = totalCount
     },
-    async newUserDataAction(userInfo: any) {
+    async newUserDataAction(userInfo: Partial<IUser>) {
       // 1.创建用户数据
       const res = await newUserData(userInfo)
       console.log(res)
@@ -39,14 +40,14 @@ const useSystemStore = defineStore('system', {
       console.log(res)
       this.getUserListDataAction({ offset: 0, size: 10 })
     },
-    async editUserDataAction(id: number, userInfo: any) {
+    async editUserDataAction(id: number, userInfo: Partial<IUser>) {
       const res = await editUserData(id, userInfo)
       console.log(res)
       this.getUserListDataAction({ offset: 0, size: 10 })
     },
 
     // 页面的网络请求
-    async getPageListDataAction(pageName: string, queryInfo: any) {
+    async getPageListDataAction(pageName: string, queryInfo: IPageQuery) {
       // 1.请求用户列表数据
       const pageListResult = await getPageListData(pageName, queryInfo)
       const { list, totalCount } = pageListResult.data
@@ -58,13 +59,13 @@ const useSystemStore = defineStore('system', {
       console.log(res)
       this.getPageListDataAction(pageName, { offset: 0, size: 10 })
     },
-    async newPageDataAction(pageName: string, pageData: any) {
+    async newPageDataAction(pageName: string, pageData: Record<string, unknown>) {
       const res = await newPageData(pageName, pageData)
       console.log(pageData)
       console.log(res)
       this.getPageListDataAction(pageName, { offset: 0, size: 10 })
     },
-    async editPageDataAction(pageName: string, id: number, pageData: any) {
+    async editPageDataAction(pageName: string, id: number, pageData: Record<string, unknown>) {
       const res = await editPageData(pageName, id, pageData)
       console.log(res)
       this.getPageListDataAction(pageName, { offset: 0, size: 10 })

--- a/src/store/main/system/type.ts
+++ b/src/store/main/system/type.ts
@@ -1,19 +1,11 @@
-export interface IUser {
-  id: number
-  name: string
-  realname: string
-  cellphone: number
-  enable: number
-  departmentId: number
-  roleId: number
-  createAt: string
-  updateAt: string
-}
+import type { IUser } from '@/service/main/types'
+
+export type { IUser }
 
 export interface ISystemState {
   usersTotalCount: number
   usersList: IUser[]
 
-  pageList: any[]
+  pageList: unknown[]
   pageTotalCount: number
 }

--- a/src/store/main/type.ts
+++ b/src/store/main/type.ts
@@ -1,8 +1,1 @@
-export interface IDepartment {
-  id: number
-  name: string
-  parentId: any
-  createAt: string
-  updateAt: string
-  leader: string
-}
+export type { IDepartment, IMenu, IRole } from '@/service/main/types'


### PR DESCRIPTION
## What changed

- Reworked the request wrapper around typed generics and async error propagation.
- Removed `any` from the request and main system service layers.
- Added shared API envelope and paginated response types.
- Added typed domain models for users, departments, roles, menus, and list queries.
- Narrowed Axios errors with `axios.isAxiosError` before handling expired sessions.

## Why

The request layer previously wrapped promises manually and allowed untyped responses to flow into Pinia stores. This change makes request and response data explicit while preserving the existing API behavior.

## Validation

- `npm ci`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Verified login, authenticated profile, role menu, and user list requests against the new API.
- Verified invalid authentication returns HTTP 401 and the preview server serves the application shell.
