### PR TITLE
Stabilize permission routes and menu mapping

### DIFF
--- a/src/components/nav-header/c-cpns/header-crumb.vue
+++ b/src/components/nav-header/c-cpns/header-crumb.vue
@@ -14,11 +14,10 @@ import { useRoute } from 'vue-router'
 import { mapPathToBreadcrumbs } from '@/utils/map-menu'
 import useLoginStore from '@/store/login/login'
 
+const route = useRoute()
+const loginStore = useLoginStore()
 const breadcrumbs = computed(() => {
-  const route = useRoute()
-  const loginStore = useLoginStore()
-  const breadcrumbs = mapPathToBreadcrumbs(loginStore.userMenus, route.path)
-  return breadcrumbs
+  return mapPathToBreadcrumbs(loginStore.userMenus, route.path)
 })
 </script>
 

--- a/src/components/nav-menu/nav-menu.vue
+++ b/src/components/nav-menu/nav-menu.vue
@@ -34,6 +34,7 @@ import { ref } from 'vue'
 import useLoginStore from '@/store/login/login'
 import { useRoute, useRouter } from 'vue-router'
 import { mapPathToMenu } from '@/utils/map-menu'
+import type { IMenu } from '@/service/main/types'
 
 // 0.定义数据
 defineProps({
@@ -50,11 +51,11 @@ const userMenus = loginStore.userMenus
 // 2.默认值的问题
 const route = useRoute()
 const currentMenu = mapPathToMenu(userMenus, route.path)
-const defaultValue = ref<string>(currentMenu.id + '')
+const defaultValue = ref(currentMenu ? String(currentMenu.id) : '')
 
 // 2.监听item点击
 const router = useRouter()
-function handleItemClick(item: any) {
+function handleItemClick(item: IMenu) {
   router.push(item.url)
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,8 @@
 import { localCache } from '@/utils/cache'
 import type { IMenu } from '@/service/login/types'
-import { firstRoute, mapMenuToRoutes } from '@/utils/map-menu'
+import { mapMenuToRoutes } from '@/utils/map-menu'
 import { createRouter, createWebHashHistory } from 'vue-router'
+import type { RouteRecordRaw } from 'vue-router'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -27,13 +28,31 @@ const router = createRouter({
   ]
 })
 
-export function addRoutesWithMenu(menus: IMenu[]) {
-  // 1.获取匹配到的所有的路由
-  const routes = mapMenuToRoutes(menus)
+let firstRoute: RouteRecordRaw | undefined
+const dynamicRouteNames = new Set<string>()
 
-  // 2.动态添加到router中
-  for (const route of routes) {
-    router.addRoute('main', route)
+function getDynamicRouteName(route: RouteRecordRaw) {
+  return `dynamic-${String(route.name ?? route.path)}`
+}
+
+export function resetDynamicRoutes() {
+  for (const routeName of dynamicRouteNames) {
+    if (router.hasRoute(routeName)) router.removeRoute(routeName)
+  }
+
+  dynamicRouteNames.clear()
+  firstRoute = undefined
+}
+
+export function addRoutesWithMenu(menus: IMenu[]) {
+  resetDynamicRoutes()
+  const routeMap = mapMenuToRoutes(menus)
+  firstRoute = routeMap.firstRoute
+
+  for (const route of routeMap.routes) {
+    const routeWithName = { ...route, name: getDynamicRouteName(route) }
+    router.addRoute('main', routeWithName)
+    dynamicRouteNames.add(routeWithName.name)
   }
 }
 

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import HYRequest from './request'
 import { BASE_URL1, TIME_OUT1 } from './config'
-import router from '@/router'
+import router, { resetDynamicRoutes } from '@/router'
 import { clearAuthCache } from '@/utils/auth'
 import { localCache } from '@/utils/cache'
 
@@ -25,6 +25,7 @@ const hyRequest = new HYRequest({
     responseInterceptorCatch: (err) => {
       if (axios.isAxiosError(err) && err.response?.status === 401) {
         clearAuthCache()
+        resetDynamicRoutes()
         if (router.currentRoute.value.path !== '/login') {
           void router.push('/login')
         }

--- a/src/store/login/login.ts
+++ b/src/store/login/login.ts
@@ -1,9 +1,9 @@
-import router, { addRoutesWithMenu } from '@/router'
+import router, { addRoutesWithMenu, resetDynamicRoutes } from '@/router'
 import { accountLogin, getRoleMenus, getUserById } from '@/service/login/login'
 import type { IAccountLoginParams, IMenu, IUserInfo } from '@/service/login/types'
 import { clearAuthCache } from '@/utils/auth'
 import { localCache } from '@/utils/cache'
-import { mapMenuToPersssions } from '@/utils/map-menu'
+import { mapMenuToPermissions } from '@/utils/map-menu'
 import { defineStore } from 'pinia'
 import useMainStore from '../main/main'
 
@@ -43,7 +43,7 @@ const useLoginStore = defineStore('login', {
       localCache.setCache('userMenus', this.userMenus)
 
       // 5.保存权限信息
-      const permissions = mapMenuToPersssions(this.userMenus)
+      const permissions = mapMenuToPermissions(this.userMenus)
       this.permissions = permissions
       localCache.setCache('permissions', this.permissions)
 
@@ -75,6 +75,7 @@ const useLoginStore = defineStore('login', {
       this.$reset()
       useMainStore().$reset()
       clearAuthCache()
+      resetDynamicRoutes()
       router.push('/login')
     }
   }

--- a/src/utils/map-menu.ts
+++ b/src/utils/map-menu.ts
@@ -1,18 +1,46 @@
 import type { RouteRecordRaw } from 'vue-router'
+import type { IMenu } from '@/service/main/types'
 
-export let firstRoute: RouteRecordRaw | undefined = undefined
+export interface IMenuRouteMap {
+  routes: RouteRecordRaw[]
+  firstRoute?: RouteRecordRaw
+}
+
+export interface IBreadcrumbItem {
+  name: string
+  path: string
+}
+
+interface IRouteModule {
+  default: RouteRecordRaw
+}
 
 function loadLocalRoutes() {
-  // 1.加载所有的模板
-  const modules: Record<string, any> = import.meta.glob('../router/main/**/*.ts', { eager: true })
+  const modules = import.meta.glob<IRouteModule>('../router/main/**/*.ts', { eager: true })
+  return Object.values(modules).map((module) => module.default)
+}
 
-  // 2.遍历所有的模板为路由对象
-  const routes: RouteRecordRaw[] = []
-  for (const key in modules) {
-    const route = modules[key].default
-    routes.push(route)
+function getChildren(menu: IMenu) {
+  return menu.children ?? []
+}
+
+function findFirstPagePath(menus: IMenu[]): string | undefined {
+  for (const menu of menus) {
+    if (menu.type === 2 && menu.url) return menu.url
+
+    const firstChildPath = findFirstPagePath(getChildren(menu))
+    if (firstChildPath) return firstChildPath
   }
-  return routes
+}
+
+function findMenuPath(menus: IMenu[], path: string, parents: IMenu[] = []): IMenu[] | undefined {
+  for (const menu of menus) {
+    const currentPath = [...parents, menu]
+    if (menu.url === path) return currentPath
+
+    const matchedPath = findMenuPath(getChildren(menu), path, currentPath)
+    if (matchedPath) return matchedPath
+  }
 }
 
 /**
@@ -20,91 +48,79 @@ function loadLocalRoutes() {
  * @param menus 菜单
  * @returns 路由
  */
-export function mapMenuToRoutes(menus: any[]) {
-  // 1.加载所有的路由对象
+export function mapMenuToRoutes(menus: IMenu[]): IMenuRouteMap {
   const localRoutes = loadLocalRoutes()
-
-  // 2.路由匹配
-  // const finalRoutes: RouteRecordRaw[] = []
-  // for (const menu of menus) {
-  //   for (const submenu of menu.children) {
-  //     const menuUrl = submenu.url
-  //     const route = localRoutes.find((item) => item.path === menuUrl)
-  //     if (route) {
-  //       finalRoutes.push(route)
-  //     }
-  //   }
-  // }
-
-  // 3.不确定有几层
+  const localRouteMap = new Map(localRoutes.map((route) => [route.path, route]))
   const finalRoutes: RouteRecordRaw[] = []
-  function _recurseGetRoute(menus: any[]) {
-    for (const menu of menus) {
+  let firstRoute: RouteRecordRaw | undefined
+
+  function collectRoutes(menuList: IMenu[]) {
+    for (const menu of menuList) {
       if (menu.type === 2) {
-        const route = localRoutes.find((item) => item.path === menu.url)
-        if (route) finalRoutes.push(route)
-        if (!firstRoute && route) firstRoute = route
-      } else {
-        if (menu.type === 1 && menu.children.length) {
-          finalRoutes.push({ path: menu.url, redirect: menu.children[0].url })
+        const route = localRouteMap.get(menu.url)
+        if (route) {
+          finalRoutes.push(route)
+          firstRoute ??= route
         }
-        _recurseGetRoute(menu.children ?? [])
+      } else {
+        const children = getChildren(menu)
+        const redirect = menu.type === 1 ? findFirstPagePath(children) : undefined
+        if (redirect) {
+          finalRoutes.push({ path: menu.url, redirect })
+        }
+        collectRoutes(children)
       }
     }
   }
-  _recurseGetRoute(menus)
 
-  return finalRoutes
+  collectRoutes(menus)
+
+  return { routes: finalRoutes, firstRoute }
 }
 
-export function mapPathToBreadcrumbs(menus: any[], path: string) {
-  const breadcrumbs: any[] = []
-  // 1.两层遍历
-  for (const menu of menus) {
-    for (const submenu of menu.children) {
-      if (path === submenu.url) {
-        breadcrumbs.push({ name: menu.name, path: menu.url })
-        breadcrumbs.push({ name: submenu.name, path: submenu.url })
-      }
-    }
-  }
-  return breadcrumbs
+export function mapPathToBreadcrumbs(menus: IMenu[], path: string): IBreadcrumbItem[] {
+  return (findMenuPath(menus, path) ?? []).map((menu) => ({
+    name: menu.name,
+    path: menu.url
+  }))
 }
 
-export function mapPathToMenu(menus: any[], path: string) {
-  for (const menu of menus) {
-    for (const submenu of menu.children) {
-      if (path === submenu.url) return submenu
-    }
-  }
+export function mapPathToMenu(menus: IMenu[], path: string): IMenu | undefined {
+  const matchedPath = findMenuPath(menus, path)
+  return matchedPath?.at(-1)
 }
 
-export function mapMenuToIds(menus: any[]) {
+export function mapMenuToIds(menus: IMenu[]): number[] {
   const ids: number[] = []
-  function _recurseGetId(menusList: any[]) {
+  function collectIds(menusList: IMenu[]) {
     for (const menu of menusList) {
-      if (menu.children) {
-        _recurseGetId(menu.children)
+      const children = getChildren(menu)
+      if (children.length) {
+        collectIds(children)
       } else {
         ids.push(menu.id)
       }
     }
   }
-  _recurseGetId(menus)
+  collectIds(menus)
   return ids
 }
 
-export function mapMenuToPersssions(menus: any[]) {
+export function mapMenuToPermissions(menus: IMenu[]): string[] {
   const permissions: string[] = []
-  function _recurseGetPermission(menuList: any[]) {
+  function collectPermissions(menuList: IMenu[]) {
     for (const menu of menuList) {
-      if (menu.type === 1 || menu.type === 2) {
-        _recurseGetPermission(menu.children ?? [])
-      } else {
+      const children = getChildren(menu)
+      if (children.length) {
+        collectPermissions(children)
+      } else if (menu.permission) {
         permissions.push(menu.permission)
       }
     }
   }
-  _recurseGetPermission(menus)
+  collectPermissions(menus)
   return permissions
 }
+
+/** @deprecated Use mapMenuToPermissions instead. */
+export const mapMenuToPersssions = mapMenuToPermissions


### PR DESCRIPTION
## What changed

- Typed the menu-to-route, breadcrumb, menu lookup, menu ID, and permission mapping utilities.
- Added nested menu traversal so breadcrumbs and active menu lookup work beyond two levels.
- Made dynamic route registration replace the previous route set instead of accumulating duplicates.
- Reset dynamic routes on logout and expired authentication.
- Replaced the misspelled permission helper at its call site while keeping a compatibility alias.

## Why

The permission layer still relied on `any`, assumed a two-level menu, and kept dynamic routes in module-level state. This update makes the Vue Router and menu flow predictable for the current API data and safer when authentication changes.

## Validation

- `npm ci`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Verified login, authenticated profile, role menu, user list, and invalid-token behavior against the new API.
- Compared the branch against `main`: one commit and six intended source files.
