### PR TITLE
Type the reusable page modules

### DIFF
--- a/src/components/page-content/page-content.vue
+++ b/src/components/page-content/page-content.vue
@@ -17,7 +17,7 @@
           <template v-if="item.type === 'time'">
             <el-table-column align="center" :prop="item.prop" :label="item.label">
               <template #default="scope">
-                {{ utcFormat(scope.row[item.prop]) }}
+                {{ item.prop ? formatTime(scope.row[item.prop]) : '' }}
               </template>
             </el-table-column>
           </template>
@@ -72,20 +72,16 @@ import useSystemStore from '@/store/main/system/system'
 import { utcFormat } from '@/utils/format'
 import { ref } from 'vue'
 import usePermission from '@/hooks/usePermission'
+import type { IPageContentConfig, PageFormData, PageRecord } from '@/types/page'
 
 interface IProps {
-  contentConfig: {
-    pageName: string
-    header?: {
-      title: string
-      btnTitle: string
-    }
-    propsList: any[]
-    childrenProps?: any
-  }
+  contentConfig: IPageContentConfig
 }
 const props = defineProps<IProps>()
-const emit = defineEmits(['newDataClick', 'editDataClick'])
+const emit = defineEmits<{
+  (event: 'newDataClick'): void
+  (event: 'editDataClick', data: PageRecord): void
+}>()
 
 // 0.判断是否有增删改查的权限
 const isCreate = usePermission(props.contentConfig.pageName, 'create')
@@ -97,7 +93,7 @@ const isQuery = usePermission(props.contentConfig.pageName, 'query')
 const systemStore = useSystemStore()
 const currentPage = ref(1)
 const pageSize = ref(10)
-function fetchPageListData(queryInfo: any = {}) {
+function fetchPageListData(queryInfo: PageFormData = {}) {
   if (!isQuery) return
   // 1.获取offset和size
   const size = pageSize.value
@@ -127,12 +123,17 @@ function handleNewData() {
 }
 
 // 5.删除和编辑操作
-function handleDeleteClick(id: number) {
+function handleDeleteClick(id: unknown) {
+  if (typeof id !== 'number') return
   systemStore.deletePageDataAction(props.contentConfig.pageName, id)
 }
 
-function handleEditClick(data: any) {
+function handleEditClick(data: PageRecord) {
   emit('editDataClick', data)
+}
+
+function formatTime(value: unknown) {
+  return typeof value === 'string' ? utcFormat(value) : ''
 }
 
 // 暴露函数

--- a/src/components/page-modal/page-modal.vue
+++ b/src/components/page-modal/page-modal.vue
@@ -21,7 +21,7 @@
                   :placeholder="item.placeholder"
                   style="width: 100%"
                 >
-                  <template v-for="value in item.options" :key="value.id">
+                  <template v-for="value in item.options ?? []" :key="value.id">
                     <el-option :value="value.id" :label="value.name" />
                   </template>
                 </el-select>
@@ -55,51 +55,48 @@
 <script setup lang="ts" name="modal">
 import useSystemStore from '@/store/main/system/system'
 import { reactive, ref } from 'vue'
+import type { IPageModalConfig, PageFormData, PageFormValue, PageRecord } from '@/types/page'
 
 // 定义props
 interface IProps {
-  modalConfig: {
-    pageName: string
-    title: string
-    formItems: any[]
-  }
-  otherInfo?: any
+  modalConfig: IPageModalConfig
+  otherInfo?: PageRecord
 }
 
 const props = defineProps<IProps>()
 
 const dialogVisible = ref(false)
 const isEdit = ref(false)
-const editData = ref()
+const editData = ref<PageRecord | null>(null)
 
 // 部门和角色的数据
 // const mainStore = useMainStore()
 // const { entireDepartments } = storeToRefs(mainStore)
 
 // 定义数据绑定
-const initialForm: any = {}
+const initialForm: PageFormData = {}
 for (const item of props.modalConfig.formItems) {
   initialForm[item.prop] = item.initialValue ?? ''
 }
-const formData = reactive(initialForm)
+const formData = reactive<PageFormData>(initialForm)
 
 // 点击确定
 const systemStore = useSystemStore()
 function handleConfirmClick() {
   dialogVisible.value = false
-  let data = { ...formData }
+  const data: PageRecord = { ...formData }
   if (props.otherInfo) {
-    data = { ...data, ...props.otherInfo }
+    Object.assign(data, props.otherInfo)
   }
   if (!isEdit.value) {
     systemStore.newPageDataAction(props.modalConfig.pageName, data)
-  } else {
+  } else if (editData.value && typeof editData.value.id === 'number') {
     systemStore.editPageDataAction(props.modalConfig.pageName, editData.value.id, data)
   }
 }
 
 // 新建或者编辑
-function setDialogVisible(isNew: boolean = true, data: any = {}) {
+function setDialogVisible(isNew = true, data: PageRecord = {}) {
   dialogVisible.value = true
   isEdit.value = !isNew
   editData.value = data
@@ -107,9 +104,22 @@ function setDialogVisible(isNew: boolean = true, data: any = {}) {
     if (isNew) {
       formData[key] = ''
     } else {
-      formData[key] = data[key]
+      formData[key] = toFormValue(data[key])
     }
   }
+}
+
+function toFormValue(value: unknown): PageFormValue {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    Array.isArray(value) ||
+    value === null
+  ) {
+    return value
+  }
+  return ''
 }
 
 defineExpose({

--- a/src/components/page-search/page-search.vue
+++ b/src/components/page-search/page-search.vue
@@ -43,22 +43,23 @@
 <script setup lang="ts" name="page-search">
 import type { ElForm } from 'element-plus'
 import { reactive, ref } from 'vue'
+import type { IPageSearchConfig, PageFormData } from '@/types/page'
 
 interface IProps {
-  searchConfig: {
-    pageName: string
-    formItems: any[]
-  }
+  searchConfig: IPageSearchConfig
 }
 const props = defineProps<IProps>()
-const emit = defineEmits(['queryClick', 'resetClick'])
+const emit = defineEmits<{
+  (event: 'queryClick', searchInfo: PageFormData): void
+  (event: 'resetClick'): void
+}>()
 
 // 1.创建表单的数据
-const initialForm: any = {}
+const initialForm: PageFormData = {}
 for (const item of props.searchConfig.formItems) {
-  initialForm[item['prop']] = item['initialValue'] ?? ''
+  initialForm[item.prop] = item.initialValue ?? ''
 }
-const searchForm = reactive(initialForm)
+const searchForm = reactive<PageFormData>(initialForm)
 
 // 2.监听按钮的点击
 const formRef = ref<InstanceType<typeof ElForm>>()

--- a/src/hooks/usePageContent.ts
+++ b/src/hooks/usePageContent.ts
@@ -1,9 +1,10 @@
 import { ref } from 'vue'
 import type PageContent from '@/components/page-content/page-content.vue'
+import type { PageFormData } from '@/types/page'
 
 function usePageContent() {
   const contentRef = ref<InstanceType<typeof PageContent>>()
-  function handleQueryClick(searchInfo: any) {
+  function handleQueryClick(searchInfo: PageFormData) {
     contentRef.value?.fetchPageListData(searchInfo)
   }
   function handleResetClick() {

--- a/src/hooks/usePageModal.ts
+++ b/src/hooks/usePageModal.ts
@@ -1,14 +1,15 @@
 import { ref } from 'vue'
 import type PageModal from '@/components/page-modal/page-modal.vue'
+import type { PageRecord } from '@/types/page'
 
-type callbackType = (item: any) => void
+type Callback = (item: PageRecord) => void
 
-function usePageModal(editCallback?: callbackType) {
+function usePageModal(editCallback?: Callback) {
   const modalRef = ref<InstanceType<typeof PageModal>>()
   function handleNewDataClick() {
     modalRef.value?.setDialogVisible()
   }
-  function handleEditDataClick(data: any) {
+  function handleEditDataClick(data: PageRecord) {
     modalRef.value?.setDialogVisible(false, data)
     if (editCallback) editCallback(data)
   }

--- a/src/service/main/system.ts
+++ b/src/service/main/system.ts
@@ -1,6 +1,14 @@
 import hyRequest from '..'
 import type { IApiResponse, IPaginatedData } from '../types'
-import type { IDepartment, IMenu, IPageQuery, IRole, IUser } from './types'
+import type {
+  IDepartment,
+  IMenu,
+  IPageQuery,
+  IPageQueryParams,
+  IRole,
+  IUser,
+  IUserPayload
+} from './types'
 
 /** 用户的网络请求 */
 export function getUserListData(queryInfo: IPageQuery) {
@@ -10,8 +18,8 @@ export function getUserListData(queryInfo: IPageQuery) {
   })
 }
 
-export function newUserData(userInfo: Partial<IUser>) {
-  return hyRequest.post<IApiResponse<IUser>, Partial<IUser>>({
+export function newUserData(userInfo: IUserPayload) {
+  return hyRequest.post<IApiResponse<IUser>, IUserPayload>({
     url: '/users',
     data: userInfo
   })
@@ -23,16 +31,16 @@ export function deleteUserData(id: number) {
   })
 }
 
-export function editUserData(id: number, userInfo: Partial<IUser>) {
-  return hyRequest.patch<IApiResponse<IUser>, Partial<IUser>>({
+export function editUserData(id: number, userInfo: IUserPayload) {
+  return hyRequest.patch<IApiResponse<IUser>, IUserPayload>({
     url: '/users/' + id,
     data: userInfo
   })
 }
 
 /** 获取页面的数据 */
-export function getPageListData(pageName: string, queryInfo: IPageQuery) {
-  return hyRequest.post<IApiResponse<IPaginatedData<Record<string, unknown>>>, IPageQuery>({
+export function getPageListData(pageName: string, queryInfo: IPageQueryParams) {
+  return hyRequest.post<IApiResponse<IPaginatedData<Record<string, unknown>>>, IPageQueryParams>({
     url: `/${pageName}/list`,
     data: queryInfo
   })

--- a/src/service/main/types.ts
+++ b/src/service/main/types.ts
@@ -3,6 +3,8 @@ export interface IPageQuery {
   size: number
 }
 
+export type IPageQueryParams = IPageQuery & Record<string, unknown>
+
 export interface IUser {
   id: number
   name: string
@@ -13,6 +15,10 @@ export interface IUser {
   roleId: number
   createAt: string
   updateAt: string
+}
+
+export interface IUserPayload extends Partial<IUser> {
+  password?: string
 }
 
 export interface IDepartment {

--- a/src/store/main/system/system.ts
+++ b/src/store/main/system/system.ts
@@ -8,8 +8,9 @@ import {
   newPageData,
   newUserData
 } from '@/service/main/system'
-import type { IPageQuery, IUser } from '@/service/main/types'
+import type { IPageQuery, IPageQueryParams, IUserPayload } from '@/service/main/types'
 import { defineStore } from 'pinia'
+import type { PageRecord } from '@/types/page'
 import type { ISystemState } from './type'
 
 const useSystemStore = defineStore('system', {
@@ -27,27 +28,24 @@ const useSystemStore = defineStore('system', {
       this.usersList = list
       this.usersTotalCount = totalCount
     },
-    async newUserDataAction(userInfo: Partial<IUser>) {
+    async newUserDataAction(userInfo: IUserPayload) {
       // 1.创建用户数据
-      const res = await newUserData(userInfo)
-      console.log(res)
+      await newUserData(userInfo)
 
       // 2.请求新的数据
-      this.getUserListDataAction({ offset: 0, size: 10 })
+      await this.getUserListDataAction({ offset: 0, size: 10 })
     },
     async deleteUserDataAction(id: number) {
-      const res = await deleteUserData(id)
-      console.log(res)
-      this.getUserListDataAction({ offset: 0, size: 10 })
+      await deleteUserData(id)
+      await this.getUserListDataAction({ offset: 0, size: 10 })
     },
-    async editUserDataAction(id: number, userInfo: Partial<IUser>) {
-      const res = await editUserData(id, userInfo)
-      console.log(res)
-      this.getUserListDataAction({ offset: 0, size: 10 })
+    async editUserDataAction(id: number, userInfo: IUserPayload) {
+      await editUserData(id, userInfo)
+      await this.getUserListDataAction({ offset: 0, size: 10 })
     },
 
     // 页面的网络请求
-    async getPageListDataAction(pageName: string, queryInfo: IPageQuery) {
+    async getPageListDataAction(pageName: string, queryInfo: IPageQueryParams) {
       // 1.请求用户列表数据
       const pageListResult = await getPageListData(pageName, queryInfo)
       const { list, totalCount } = pageListResult.data
@@ -55,20 +53,16 @@ const useSystemStore = defineStore('system', {
       this.pageTotalCount = totalCount
     },
     async deletePageDataAction(pageName: string, id: number) {
-      const res = await deletePageData(pageName, id)
-      console.log(res)
-      this.getPageListDataAction(pageName, { offset: 0, size: 10 })
+      await deletePageData(pageName, id)
+      await this.getPageListDataAction(pageName, { offset: 0, size: 10 })
     },
-    async newPageDataAction(pageName: string, pageData: Record<string, unknown>) {
-      const res = await newPageData(pageName, pageData)
-      console.log(pageData)
-      console.log(res)
-      this.getPageListDataAction(pageName, { offset: 0, size: 10 })
+    async newPageDataAction(pageName: string, pageData: PageRecord) {
+      await newPageData(pageName, pageData)
+      await this.getPageListDataAction(pageName, { offset: 0, size: 10 })
     },
-    async editPageDataAction(pageName: string, id: number, pageData: Record<string, unknown>) {
-      const res = await editPageData(pageName, id, pageData)
-      console.log(res)
-      this.getPageListDataAction(pageName, { offset: 0, size: 10 })
+    async editPageDataAction(pageName: string, id: number, pageData: PageRecord) {
+      await editPageData(pageName, id, pageData)
+      await this.getPageListDataAction(pageName, { offset: 0, size: 10 })
     }
   }
 })

--- a/src/store/main/system/type.ts
+++ b/src/store/main/system/type.ts
@@ -1,4 +1,5 @@
 import type { IUser } from '@/service/main/types'
+import type { PageRecord } from '@/types/page'
 
 export type { IUser }
 
@@ -6,6 +7,6 @@ export interface ISystemState {
   usersTotalCount: number
   usersList: IUser[]
 
-  pageList: unknown[]
+  pageList: PageRecord[]
   pageTotalCount: number
 }

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,0 +1,53 @@
+export type PageFormValue = string | number | boolean | string[] | null | undefined
+
+export type PageFormData = Record<string, PageFormValue>
+
+export interface ISelectOption {
+  id: number | string
+  name: string
+}
+
+export type FormItemType = 'input' | 'password' | 'date-picker' | 'select' | 'custom'
+
+export interface IFormItem {
+  label: string
+  prop: string
+  type: FormItemType
+  placeholder?: string
+  initialValue?: PageFormValue
+  options?: ISelectOption[]
+  slotName?: string
+}
+
+export interface IPageSearchConfig {
+  pageName: string
+  formItems: IFormItem[]
+}
+
+export type TableColumnType = 'normal' | 'time' | 'handler' | 'selection' | 'index'
+
+export interface ITableColumn {
+  type?: TableColumnType
+  prop?: string
+  label: string
+  width?: string | number
+  [key: string]: unknown
+}
+
+export interface IPageContentConfig {
+  pageName: string
+  header?: {
+    title: string
+    btnTitle: string
+  }
+  propsList: ITableColumn[]
+  childrenProps?: Record<string, unknown>
+}
+
+export interface IPageModalConfig {
+  pageName: string
+  title: string
+  formItems: IFormItem[]
+}
+
+export type PageRecord = Record<string, unknown>

--- a/src/views/main/system/department/c-cpns/page-content.vue
+++ b/src/views/main/system/department/c-cpns/page-content.vue
@@ -63,14 +63,18 @@ import { storeToRefs } from 'pinia'
 import useSystemStore from '@/store/main/system/system'
 import { utcFormat } from '@/utils/format'
 import { ref } from 'vue'
+import type { PageFormData, PageRecord } from '@/types/page'
 
-const emit = defineEmits(['newDataClick', 'editDataClick'])
+const emit = defineEmits<{
+  (event: 'newDataClick'): void
+  (event: 'editDataClick', data: PageRecord): void
+}>()
 
 // 1.请求数据
 const systemStore = useSystemStore()
 const currentPage = ref(1)
 const pageSize = ref(10)
-function fetchPageListData(queryInfo: any = {}) {
+function fetchPageListData(queryInfo: PageFormData = {}) {
   // 1.获取offset和size
   const size = pageSize.value
   const offset = (currentPage.value - 1) * size
@@ -103,7 +107,7 @@ function handleDeleteClick(id: number) {
   systemStore.deletePageDataAction('department', id)
 }
 
-function handleEditClick(data: any) {
+function handleEditClick(data: PageRecord) {
   emit('editDataClick', data)
 }
 

--- a/src/views/main/system/department/c-cpns/page-modal.vue
+++ b/src/views/main/system/department/c-cpns/page-modal.vue
@@ -33,17 +33,24 @@ import useMainStore from '@/store/main/main'
 import useSystemStore from '@/store/main/system/system'
 import { storeToRefs } from 'pinia'
 import { reactive, ref } from 'vue'
+import type { PageRecord } from '@/types/page'
+
+interface IDepartmentFormData {
+  name: string
+  leader: string
+  parentId: number | string
+}
 
 const dialogVisible = ref(false)
 const isEdit = ref(false)
-const editData = ref()
+const editData = ref<PageRecord | null>(null)
 
 // 部门和角色的数据
 const mainStore = useMainStore()
 const { entireDepartments } = storeToRefs(mainStore)
 
 // 定义数据绑定
-const formData = reactive<any>({
+const formData = reactive<IDepartmentFormData>({
   name: '',
   leader: '',
   parentId: ''
@@ -53,25 +60,36 @@ const formData = reactive<any>({
 const systemStore = useSystemStore()
 function handleConfirmClick() {
   dialogVisible.value = false
+  const departmentData: PageRecord = {
+    name: formData.name,
+    leader: formData.leader,
+    parentId: formData.parentId === '' ? null : Number(formData.parentId)
+  }
   if (!isEdit.value) {
-    systemStore.newPageDataAction('department', formData)
-  } else {
-    systemStore.editPageDataAction('department', editData.value.id, formData)
+    systemStore.newPageDataAction('department', departmentData)
+  } else if (editData.value && typeof editData.value.id === 'number') {
+    systemStore.editPageDataAction('department', editData.value.id, departmentData)
   }
 }
 
 // 新建或者编辑
-function setDialogVisible(isNew: boolean = true, data: any = {}) {
+function setDialogVisible(isNew = true, data: PageRecord = {}) {
   dialogVisible.value = true
   isEdit.value = !isNew
   editData.value = data
-  for (const key in formData) {
-    if (isNew) {
-      formData[key] = ''
-    } else {
-      formData[key] = data[key]
-    }
-  }
+  Object.assign(formData, {
+    name: isNew ? '' : toStringValue(data.name),
+    leader: isNew ? '' : toStringValue(data.leader),
+    parentId: isNew ? '' : toNumberValue(data.parentId)
+  })
+}
+
+function toStringValue(value: unknown) {
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+}
+
+function toNumberValue(value: unknown) {
+  return typeof value === 'number' || typeof value === 'string' ? value : ''
 }
 
 defineExpose({

--- a/src/views/main/system/department/config/content.config.ts
+++ b/src/views/main/system/department/config/content.config.ts
@@ -1,4 +1,6 @@
-const contentConfig = {
+import type { IPageContentConfig } from '@/types/page'
+
+const contentConfig: IPageContentConfig = {
   pageName: 'department',
   header: {
     title: '部门列表',

--- a/src/views/main/system/department/config/modal.config.ts
+++ b/src/views/main/system/department/config/modal.config.ts
@@ -1,4 +1,6 @@
-const modalConfig = {
+import type { IPageModalConfig } from '@/types/page'
+
+const modalConfig: IPageModalConfig = {
   pageName: 'department',
   title: '新建部门',
   formItems: [

--- a/src/views/main/system/department/config/search.config.ts
+++ b/src/views/main/system/department/config/search.config.ts
@@ -1,4 +1,6 @@
-const searchConfig = {
+import type { IPageSearchConfig } from '@/types/page'
+
+const searchConfig: IPageSearchConfig = {
   pageName: 'department',
   formItems: [
     {

--- a/src/views/main/system/department/department.vue
+++ b/src/views/main/system/department/department.vue
@@ -33,7 +33,7 @@ const mainStore = useMainStore()
 const modalConfigRef = computed(() => {
   modalConfig.formItems.forEach((item) => {
     if (item.prop === 'parentId') {
-      item.options = mainStore.entireDepartments as any
+      item.options = mainStore.entireDepartments
     }
   })
   return modalConfig

--- a/src/views/main/system/menu/config/content.config.ts
+++ b/src/views/main/system/menu/config/content.config.ts
@@ -1,4 +1,6 @@
-const contentConfig = {
+import type { IPageContentConfig } from '@/types/page'
+
+const contentConfig: IPageContentConfig = {
   pageName: 'menu',
   propsList: [
     { prop: 'name', label: '菜单名称', width: '180px' },

--- a/src/views/main/system/role/config/content.config.ts
+++ b/src/views/main/system/role/config/content.config.ts
@@ -1,4 +1,6 @@
-const contentConfig = {
+import type { IPageContentConfig } from '@/types/page'
+
+const contentConfig: IPageContentConfig = {
   pageName: 'role',
   header: {
     title: '角色列表',

--- a/src/views/main/system/role/config/modal.config.ts
+++ b/src/views/main/system/role/config/modal.config.ts
@@ -1,4 +1,6 @@
-const modalConfig = {
+import type { IPageModalConfig } from '@/types/page'
+
+const modalConfig: IPageModalConfig = {
   pageName: 'role',
   title: '新建角色',
   formItems: [
@@ -16,6 +18,8 @@ const modalConfig = {
     },
     {
       type: 'custom',
+      label: '菜单权限',
+      prop: 'menuList',
       slotName: 'menulist'
     }
   ]

--- a/src/views/main/system/role/config/search.config.ts
+++ b/src/views/main/system/role/config/search.config.ts
@@ -1,4 +1,6 @@
-const searchConfig = {
+import type { IPageSearchConfig } from '@/types/page'
+
+const searchConfig: IPageSearchConfig = {
   pageName: 'role',
   formItems: [
     {

--- a/src/views/main/system/role/role.vue
+++ b/src/views/main/system/role/role.vue
@@ -44,6 +44,8 @@ import { storeToRefs } from 'pinia'
 import { ref, nextTick } from 'vue'
 import { mapMenuToIds } from '@/utils/map-menu'
 import type { ElTree } from 'element-plus'
+import type { IMenu } from '@/service/main/types'
+import type { PageRecord } from '@/types/page'
 
 const { contentRef, handleQueryClick, handleResetClick } = usePageContent()
 const { modalRef, handleNewDataClick, handleEditDataClick } = usePageModal(editCallback)
@@ -51,17 +53,28 @@ const { modalRef, handleNewDataClick, handleEditDataClick } = usePageModal(editC
 // 菜单的展示
 const mainStore = useMainStore()
 const { entireMenus } = storeToRefs(mainStore)
-const otherInfo = ref({})
-function handleMenuCheckChange(data1: any, data2: any) {
-  const menuList = [...data2.checkedKeys, ...data2.halfCheckedKeys]
+const otherInfo = ref<PageRecord>({})
+interface ITreeCheckState {
+  checkedKeys: Array<number | string>
+  halfCheckedKeys: Array<number | string>
+}
+function handleMenuCheckChange(_data: IMenu, data: ITreeCheckState) {
+  const menuList = [...data.checkedKeys, ...data.halfCheckedKeys]
   otherInfo.value = { menuList }
 }
 const treeRef = ref<InstanceType<typeof ElTree>>()
-function editCallback(data: any) {
+function editCallback(data: PageRecord) {
   nextTick(() => {
-    const menuList = mapMenuToIds(data.menuList)
+    const menus = Array.isArray(data.menuList) ? data.menuList.filter(isMenu) : []
+    const menuList = mapMenuToIds(menus)
     treeRef.value?.setCheckedKeys(menuList)
   })
+}
+
+function isMenu(value: unknown): value is IMenu {
+  if (typeof value !== 'object' || value === null) return false
+  const menu = value as Record<string, unknown>
+  return typeof menu.id === 'number' && typeof menu.name === 'string'
 }
 </script>
 

--- a/src/views/main/system/user/c-cpns/page-content.vue
+++ b/src/views/main/system/user/c-cpns/page-content.vue
@@ -70,14 +70,18 @@ import { storeToRefs } from 'pinia'
 import useSystemStore from '@/store/main/system/system'
 import { utcFormat } from '@/utils/format'
 import { ref } from 'vue'
+import type { PageFormData, PageRecord } from '@/types/page'
 
-const emit = defineEmits(['newDataClick', 'editDataClick'])
+const emit = defineEmits<{
+  (event: 'newDataClick'): void
+  (event: 'editDataClick', data: PageRecord): void
+}>()
 
 // 1.请求数据
 const systemStore = useSystemStore()
 const currentPage = ref(1)
 const pageSize = ref(10)
-function fetchUserListData(queryInfo: any = {}) {
+function fetchUserListData(queryInfo: PageFormData = {}) {
   // 1.获取offset和size
   const size = pageSize.value
   const offset = (currentPage.value - 1) * size
@@ -110,7 +114,7 @@ function handleDeleteClick(id: number) {
   systemStore.deleteUserDataAction(id)
 }
 
-function handleEditClick(data: any) {
+function handleEditClick(data: PageRecord) {
   emit('editDataClick', data)
 }
 

--- a/src/views/main/system/user/c-cpns/page-modal.vue
+++ b/src/views/main/system/user/c-cpns/page-modal.vue
@@ -46,17 +46,28 @@ import useMainStore from '@/store/main/main'
 import useSystemStore from '@/store/main/system/system'
 import { storeToRefs } from 'pinia'
 import { reactive, ref } from 'vue'
+import type { IUserPayload } from '@/service/main/types'
+import type { PageRecord } from '@/types/page'
+
+interface IUserFormData {
+  name: string
+  realname: string
+  password: string
+  cellphone: string
+  roleId: number | string
+  departmentId: number | string
+}
 
 const dialogVisible = ref(false)
 const isEdit = ref(false)
-const editData = ref()
+const editData = ref<PageRecord | null>(null)
 
 // 部门和角色的数据
 const mainStore = useMainStore()
 const { entireDepartments, entireRoles } = storeToRefs(mainStore)
 
 // 定义数据绑定
-const formData = reactive<any>({
+const formData = reactive<IUserFormData>({
   name: '',
   realname: '',
   password: '',
@@ -69,25 +80,47 @@ const formData = reactive<any>({
 const systemStore = useSystemStore()
 function handleConfirmClick() {
   dialogVisible.value = false
+  const userData = toUserPayload()
   if (!isEdit.value) {
-    systemStore.newUserDataAction(formData)
-  } else {
-    systemStore.editUserDataAction(editData.value.id, formData)
+    systemStore.newUserDataAction(userData)
+  } else if (editData.value && typeof editData.value.id === 'number') {
+    systemStore.editUserDataAction(editData.value.id, userData)
   }
 }
 
 // 新建或者编辑
-function setDialogVisible(isNew: boolean = true, data: any = {}) {
+function setDialogVisible(isNew = true, data: PageRecord = {}) {
   dialogVisible.value = true
   isEdit.value = !isNew
   editData.value = data
-  for (const key in formData) {
-    if (isNew) {
-      formData[key] = ''
-    } else {
-      formData[key] = data[key]
-    }
+  Object.assign(formData, {
+    name: isNew ? '' : toStringValue(data.name),
+    realname: isNew ? '' : toStringValue(data.realname),
+    password: '',
+    cellphone: isNew ? '' : toStringValue(data.cellphone),
+    roleId: isNew ? '' : toNumberValue(data.roleId),
+    departmentId: isNew ? '' : toNumberValue(data.departmentId)
+  })
+}
+
+function toUserPayload(): IUserPayload {
+  const userData: IUserPayload = {
+    name: formData.name,
+    realname: formData.realname,
+    cellphone: Number(formData.cellphone),
+    roleId: Number(formData.roleId),
+    departmentId: Number(formData.departmentId)
   }
+  if (formData.password) userData.password = formData.password
+  return userData
+}
+
+function toStringValue(value: unknown) {
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+}
+
+function toNumberValue(value: unknown) {
+  return typeof value === 'number' || typeof value === 'string' ? value : ''
 }
 
 defineExpose({

--- a/src/views/main/system/user/c-cpns/page-search.vue
+++ b/src/views/main/system/user/c-cpns/page-search.vue
@@ -67,7 +67,6 @@ const userSearchForm = reactive({
 // 2.监听按钮的点击
 const formRef = ref<InstanceType<typeof ElForm>>()
 function handleResetClick() {
-  console.log(formRef.value)
   formRef.value?.resetFields()
   emit('resetClick')
 }

--- a/src/views/main/system/user/user.vue
+++ b/src/views/main/system/user/user.vue
@@ -1,29 +1,30 @@
 <template>
   <div class="user">
     <!-- 1.搜索区域 -->
-    <page-search @query-click="handleQueryClick" @reset-click="handleResetClick" />
+    <UserPageSearch @query-click="handleQueryClick" @reset-click="handleResetClick" />
 
     <!-- 2.展示区域 -->
-    <page-content
+    <UserPageContent
       ref="contentRef"
       @new-data-click="handleNewDataClick"
       @edit-data-click="handleEditDataClick"
     />
 
     <!-- 3.新建和编辑 -->
-    <page-modal ref="modalRef" />
+    <UserPageModal ref="modalRef" />
   </div>
 </template>
 
 <script setup lang="ts" name="user">
-import PageSearch from './c-cpns/page-search.vue'
-import PageContent from './c-cpns/page-content.vue'
-import PageModal from './c-cpns/page-modal.vue'
+import UserPageSearch from './c-cpns/page-search.vue'
+import UserPageContent from './c-cpns/page-content.vue'
+import UserPageModal from './c-cpns/page-modal.vue'
 import { ref } from 'vue'
+import type { PageFormData, PageRecord } from '@/types/page'
 
 // 1.重置功能
-const contentRef = ref<InstanceType<typeof PageContent>>()
-function handleQueryClick(searchInfo: any) {
+const contentRef = ref<InstanceType<typeof UserPageContent>>()
+function handleQueryClick(searchInfo: PageFormData) {
   contentRef.value?.fetchUserListData(searchInfo)
 }
 function handleResetClick() {
@@ -31,11 +32,11 @@ function handleResetClick() {
 }
 
 // 2.新建和编辑数据
-const modalRef = ref<InstanceType<typeof PageModal>>()
+const modalRef = ref<InstanceType<typeof UserPageModal>>()
 function handleNewDataClick() {
   modalRef.value?.setDialogVisible()
 }
-function handleEditDataClick(data: any) {
+function handleEditDataClick(data: PageRecord) {
   modalRef.value?.setDialogVisible(false, data)
 }
 </script>


### PR DESCRIPTION
## What changed

- Added shared TypeScript contracts for page search, table, modal, form values, and CRUD records.
- Typed the reusable page components and their composable hooks.
- Typed the department, role, and user page data flows, including form payload conversion.
- Removed page-level `any` values and debug logging from the CRUD layer.
- Awaited list refreshes after create, edit, and delete operations.

## Why

The reusable admin pages still relied on loosely typed configuration and form records. This made changes easy to break and left API payload conversion implicit. The new contracts make the Vue component boundaries explicit while preserving the existing backend behavior.

## Validation

- `npm ci`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Verified login, profile, role menu, user list, and invalid-token behavior against the new API.
- Verified department, role, and menu list endpoints and the preview application shell.
- Compared the branch against `main`: one commit and 25 intended source files.
