### PR TITLE
Restore the session before mounting the app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import router from './router'
 import store from './store'
+import useLoginStore from './store/login/login'
 import 'normalize.css'
 
 import './assets/css/index.less'
@@ -15,4 +16,18 @@ for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
 
 app.use(store)
 app.use(router)
-app.mount('#app')
+
+const loginStore = useLoginStore()
+
+async function bootstrapApp() {
+  try {
+    await loginStore.loadLocalDataAction()
+  } catch {
+    loginStore.logoutAction()
+  }
+
+  await router.isReady()
+  app.mount('#app')
+}
+
+void bootstrapApp()

--- a/src/store/login/login.ts
+++ b/src/store/login/login.ts
@@ -49,7 +49,7 @@ const useLoginStore = defineStore('login', {
 
       // 5.获取所有的数据
       const mainStore = useMainStore()
-      mainStore.fetchEntireDataAction()
+      await mainStore.fetchEntireDataAction()
 
       // 5.动态添加路由
       addRoutesWithMenu(this.userMenus)
@@ -58,7 +58,7 @@ const useLoginStore = defineStore('login', {
       router.push('/main')
     },
 
-    loadLocalDataAction() {
+    async loadLocalDataAction() {
       this.token = localCache.getCache<string>('token') ?? ''
       this.userInfo = localCache.getCache<IUserInfo>('userInfo') ?? null
       this.userMenus = localCache.getCache<IMenu[]>('userMenus') ?? []
@@ -67,7 +67,7 @@ const useLoginStore = defineStore('login', {
       if (this.token && this.userMenus.length) {
         addRoutesWithMenu(this.userMenus) // 获取所有的数据
         const mainStore = useMainStore()
-        mainStore.fetchEntireDataAction()
+        await mainStore.fetchEntireDataAction()
       }
     },
 


### PR DESCRIPTION
## What changed

- Restore the cached login state before the Vue app mounts.
- Register permission routes and load shared department, role, and menu data during startup.
- Wait for the router to finish its initial navigation before mounting the app.
- Await shared data loading after a fresh login as well.
- Fall back to the login flow when cached-session bootstrap fails.

## Why

The login store already had a cache restoration action, but the application never called it during startup. Refreshing an authenticated route could therefore lose dynamic routes or render before shared data was ready. This change makes authenticated startup deterministic while preserving the existing API and routing behavior.

## Validation

- `npm ci`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- Verified the preview app opens the login page without a session and has no browser console errors.
- Verified login, profile, role menu, user list, and invalid-token behavior against the new API.
- Compared the branch against `main`: one commit and two intended source files.
