### PR TITLE
Add the frontend quality gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,32 @@
+name: Quality checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npm run type-check
+      - name: Lint
+        run: npm run lint:check
+      - name: Build
+        run: npm run build-only

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+    "lint:check": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/src/store/main/main.ts
+++ b/src/store/main/main.ts
@@ -16,9 +16,11 @@ const useMainStore = defineStore('main', {
   }),
   actions: {
     async fetchEntireDataAction() {
-      const departmentResult = await getDepartmentData({ offset: 0, size: 100 })
-      const roleResult = await getRoleData({ offset: 0, size: 100 })
-      const menuResult = await getMenuData()
+      const [departmentResult, roleResult, menuResult] = await Promise.all([
+        getDepartmentData({ offset: 0, size: 100 }),
+        getRoleData({ offset: 0, size: 100 }),
+        getMenuData()
+      ])
 
       this.entireDepartments = departmentResult.data.list
       this.entireRoles = roleResult.data.list


### PR DESCRIPTION
## What changed

- add a GitHub Actions quality workflow for type checking, lint validation, and production builds
- add a read-only `lint:check` script for pull request validation
- load departments, roles, and menus in parallel during session bootstrap

## Validation

- `npm run type-check`
- `npm run lint:check`
- `npm run build-only`
- API login, profile, menu, user list, and invalid-token checks
- preview server smoke test

## Notes

This keeps the existing toolchain unchanged and isolates dependency upgrades for a later migration.